### PR TITLE
splash screen

### DIFF
--- a/scp2/src/main/AndroidManifest.xml
+++ b/scp2/src/main/AndroidManifest.xml
@@ -43,13 +43,16 @@
         <activity android:name=".ui.activity.GalleryActivity"/>
 
         <activity
-            android:name=".ui.activity.LicenceActivity">
+            android:name=".ui.activity.SplashActivity"
+            android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <activity android:name=".ui.activity.LicenceActivity"/>
 
         <!--service-->
         <service android:name="ru.dante.scpfoundation.service.DownloadAllService"/>

--- a/scp2/src/main/java/ru/dante/scpfoundation/ui/activity/SplashActivity.java
+++ b/scp2/src/main/java/ru/dante/scpfoundation/ui/activity/SplashActivity.java
@@ -1,0 +1,17 @@
+package ru.dante.scpfoundation.ui.activity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+public class SplashActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        startActivity(new Intent(this, LicenceActivity.class));
+        finishAffinity();
+    }
+
+}

--- a/scp2/src/main/res/drawable/background_splash.xml
+++ b/scp2/src/main/res/drawable/background_splash.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:drawable="@color/colorPrimary"/>
+
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@mipmap/ic_launcher"/>
+    </item>
+
+</layer-list>

--- a/scp2/src/main/res/values/styles.xml
+++ b/scp2/src/main/res/values/styles.xml
@@ -210,4 +210,8 @@
         <item name="android:textColor">@color/material_blue_gray_50</item>
     </style>
 
+    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@drawable/background_splash</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Качественный Splash, сделанный с учётом специфики Android,

Он никак не влияет на загрузку данных (по крайней мере в этом Pull'e), но её можно переместить туда (мне лень разбираться со структурой проекта).

Тут нет никаких задержек или чего-то подобного, просто вместо обычного "белого" экрана загрузки Android (который есть в любом случае) показан фон с логотипчиком.